### PR TITLE
Refresh editor support list

### DIFF
--- a/src/content/pages/download.rst
+++ b/src/content/pages/download.rst
@@ -75,6 +75,7 @@ There are editor modes which support interactive editing:
 
   * `Vim mode (for Idris 2) <https://github.com/edwinb/idris2-vim>`_
   * `Emacs mode (for Idris 2) <https://github.com/idris-community/idris2-mode>`_
+  * `Language Server Protocol <https://github.com/idris-community/idris2-lsp>
 
 * Idris 1
 

--- a/src/content/pages/download.rst
+++ b/src/content/pages/download.rst
@@ -71,14 +71,12 @@ Editor Support
 
 There are editor modes which support interactive editing:
 
+* Idris 2
+
+  * `Vim mode (for Idris 2) <https://github.com/edwinb/idris2-vim>`_
+
 * Idris 1
 
   * `Atom package <https://atom.io/packages/language-idris>`_
   * `Vim mode (for Idris 1) <https://github.com/idris-hackers/idris-vim>`_
   * `Emacs mode <https://github.com/idris-hackers/idris-mode>`_
-
-* Idris 2
-
-  * `Vim mode (for Idris 2) <https://github.com/edwinb/idris2-vim>`_
-
-

--- a/src/content/pages/download.rst
+++ b/src/content/pages/download.rst
@@ -75,7 +75,7 @@ There are editor modes which support interactive editing:
 
   * `Vim mode (for Idris 2) <https://github.com/edwinb/idris2-vim>`_
   * `Emacs mode (for Idris 2) <https://github.com/idris-community/idris2-mode>`_
-  * `Language Server Protocol <https://github.com/idris-community/idris2-lsp>
+  * `Language Server Protocol <https://github.com/idris-community/idris2-lsp>`
 
 * Idris 1
 

--- a/src/content/pages/download.rst
+++ b/src/content/pages/download.rst
@@ -75,7 +75,7 @@ There are editor modes which support interactive editing:
 
   * `Vim mode (for Idris 2) <https://github.com/edwinb/idris2-vim>`_
   * `Emacs mode (for Idris 2) <https://github.com/idris-community/idris2-mode>`_
-  * `Language Server Protocol <https://github.com/idris-community/idris2-lsp>`
+  * `Language Server Protocol <https://github.com/idris-community/idris2-lsp>`_
 
 * Idris 1
 

--- a/src/content/pages/download.rst
+++ b/src/content/pages/download.rst
@@ -74,11 +74,12 @@ There are editor modes which support interactive editing:
 * Idris 2
 
   * `Vim mode (for Idris 2) <https://github.com/edwinb/idris2-vim>`_
-  * `Emacs mode (for Idris 2) <https://github.com/idris-community/idris2-mode>`_
+  * `Emacs mode (for Idris 1 and 2) <https://github.com/idris-hackers/idris-mode>`_
+  * `Emacs mode (for Idris 2 only) <https://github.com/idris-community/idris2-mode>`_
   * `Language Server Protocol <https://github.com/idris-community/idris2-lsp>`_
 
 * Idris 1
 
   * `Atom package <https://atom.io/packages/language-idris>`_
   * `Vim mode (for Idris 1) <https://github.com/idris-hackers/idris-vim>`_
-  * `Emacs mode (for Idris 1) <https://github.com/idris-hackers/idris-mode>`_
+  * `Emacs mode (for Idris 1 and 2) <https://github.com/idris-hackers/idris-mode>`_

--- a/src/content/pages/download.rst
+++ b/src/content/pages/download.rst
@@ -80,6 +80,6 @@ There are editor modes which support interactive editing:
 
 * Idris 1
 
-  * `Atom package <https://atom.io/packages/language-idris>`_
   * `Vim mode (for Idris 1) <https://github.com/idris-hackers/idris-vim>`_
   * `Emacs mode (for Idris 1 and 2) <https://github.com/idris-hackers/idris-mode>`_
+  * `(DEPRECATED) <https://github.blog/news-insights/product-news/sunsetting-atom/>`_ `Atom package <https://atom.io/packages/language-idris>`__

--- a/src/content/pages/download.rst
+++ b/src/content/pages/download.rst
@@ -74,9 +74,10 @@ There are editor modes which support interactive editing:
 * Idris 2
 
   * `Vim mode (for Idris 2) <https://github.com/edwinb/idris2-vim>`_
+  * `Emacs mode (for Idris 2) <https://github.com/idris-community/idris2-mode>`_
 
 * Idris 1
 
   * `Atom package <https://atom.io/packages/language-idris>`_
   * `Vim mode (for Idris 1) <https://github.com/idris-hackers/idris-vim>`_
-  * `Emacs mode <https://github.com/idris-hackers/idris-mode>`_
+  * `Emacs mode (for Idris 1) <https://github.com/idris-hackers/idris-mode>`_


### PR DESCRIPTION
The minor changes aim to be consistent with the [wiki page hosted on Github](https://github.com/idris-lang/Idris2/wiki/Editor-Support).

Also, it raises a question if the link to Atom should be kept as [Atom was "Sunset" on 15 December 2022](https://github.blog/2022-06-08-sunsetting-atom/).