### PR TITLE
Make github link go to idris-lang org, not edwinb

### DIFF
--- a/src/notmyidea-cms/templates/base.html
+++ b/src/notmyidea-cms/templates/base.html
@@ -89,7 +89,7 @@
         <footer id="footer" class="body">
                 <address id="about" class="vcard body">
                 Proudly powered by <a href="http://alexis.notmyidea.org/pelican/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a> (not Idris :)).
-                Patches are welcome on <a href="https://github.com/edwinb/idris-lang.org/">github</a>!
+                Patches are welcome on <a href="https://github.com/idris-lang/idris-lang.github.io">github</a>!
                 </address><!-- /#about -->
 
                 <p>The theme is «notmyidea-cms», a modified version of «notmyidea», the default theme.</p>


### PR DESCRIPTION
If this codebase is deployed, links should go to this codebase, instead of the repo it was forked from.