### PR TITLE
update download page with pack instructions

### DIFF
--- a/src/content/pages/download.rst
+++ b/src/content/pages/download.rst
@@ -26,7 +26,7 @@ You will have to use ``pack build`` instead of ``idris2 --build`` to compile a
 package.
 
 If you already use ``pack``, you can update your Idris version to the latest version 
-in development by using ``pack switch latest``[#f1]_. If you wish to use a specific
+in development by using ``pack switch latest`` ([#f1]_). If you wish to use a specific
 release with ``pack``, currently the only way to do this is to find the release
 date, and then switch to its nightly collection by using, for example,
 ``pack switch nightly-231222`` (which would switch to the 0.7.0 release).
@@ -112,6 +112,7 @@ There are editor modes which support interactive editing:
   * `Emacs mode (for Idris 1 and 2) <https://github.com/idris-hackers/idris-mode>`_
   * `(DEPRECATED) <https://github.blog/news-insights/product-news/sunsetting-atom/>`_ `Atom package <https://atom.io/packages/language-idris>`__
 
-.. rubric:: Footnotes
+Footnotes
+---------
 
 .. [#f1] This version point to the latest git commit (``HEAD``) of the Idris 2 project.

--- a/src/content/pages/download.rst
+++ b/src/content/pages/download.rst
@@ -4,20 +4,26 @@ Download
 Idris 2
 -------
 
-To get the cutting edge version of Idris 2, use the package manager ``pack`` –
+The easiest way to install and use Idris 2, is to use the package manager ``pack`` –
 please see `pack's install & usage instructions <https://github.com/stefan-hoeck/idris2-pack>`_.
 
-``pack`` will also handle your dependencies using the
+This will install the cutting edge version of the compiler, as well as handle
+your dependencies using the
 `pack collection <https://github.com/stefan-hoeck/idris2-pack-db/blob/main/collections/HEAD.toml>`_.
 You will have to use ``pack build`` instead of ``idris2 --build`` to compile a
 package.
 
 If you already use ``pack``, you can update your Idris version to the latest git
-commit (``HEAD``) by using ``pack switch latest``.
+commit (``HEAD``) by using ``pack switch latest``. If you wish to use a specific
+release with ``pack``, currently the only way to do this is to find the release
+date, and then switch to its nightly collection by using, for example,
+``pack switch nightly-231222`` (which would switch to the 0.7.0 release).
 
-Alternatively, the latest formally released version is Idris2-0.7.0,
+The latest formally released version is Idris2-0.7.0,
 `released 2023-12-22 <{filename}../posts/idris2-0-7-0-released.rst>`_,
-with its associated source tarball:
+with its associated source tarball, which could alternatively be used for
+installation, forgoing ``pack`` (packages would have to be managed manually, via
+scripts, or via other software):
 
 * `idris2-0.7.0.tgz <{static}../releases/idris2-0.7.0.tgz>`_
   `(SHA 256 hash) <{static}../releases/idris2-0.7.0.tgz.sha256>`__

--- a/src/content/pages/download.rst
+++ b/src/content/pages/download.rst
@@ -4,23 +4,27 @@ Download
 Idris 2
 -------
 
-To get the cutting edge version of the compiler, use the package manager ``pack`` –
+To get the cutting edge version of Idris 2, use the package manager ``pack`` –
 please see `pack's install & usage instructions <https://github.com/stefan-hoeck/idris2-pack>`_.
 
-``pack`` will also handle your dependencies using the `pack collection <https://github.com/stefan-hoeck/idris2-pack-db/blob/main/collections/HEAD.toml>`_.
-You will have to use ``pack build`` instead of idris to compile.
+``pack`` will also handle your dependencies using the
+`pack collection <https://github.com/stefan-hoeck/idris2-pack-db/blob/main/collections/HEAD.toml>`_.
+You will have to use ``pack build`` instead of ``idris2 --build`` to compile a
+package.
 
-If you already use ``pack``, you can update your idris version by using ``pack switch latest``.
+If you already use ``pack``, you can update your Idris version to the latest git
+commit (``HEAD``) by using ``pack switch latest``.
 
-The latest released version is Idris2-0.7.0,
-`released 2023-12-22 <{filename}../posts/idris2-0-7-0-released.rst>`_.
+Alternatively, the latest formally released version is Idris2-0.7.0,
+`released 2023-12-22 <{filename}../posts/idris2-0-7-0-released.rst>`_,
+with its associated source tarball:
 
-And its associated tarballs
-  `idris2-0.7.0.tgz <{static}../releases/idris2-0.7.0.tgz>`_
-  `(SHA 256 hash) <{static}../releases/idris2-0.7.0.tgz.sha256>`__.
+* `idris2-0.7.0.tgz <{static}../releases/idris2-0.7.0.tgz>`_
+  `(SHA 256 hash) <{static}../releases/idris2-0.7.0.tgz.sha256>`__
 
-Both include generated Scheme sources sufficient for bootstrapping, so you don't
-need an existing Idris 2 system to build. You need:
+Both ``pack`` and the release tarball include generated Scheme sources
+sufficient for bootstrapping, so you don't need an existing Idris 2 system to
+build. You need:
 
 * Either `Chez Scheme <https://cisco.github.io/ChezScheme/>`_ or `Racket
   <https://racket-lang.org>`_ to build the generated Scheme source

--- a/src/content/pages/download.rst
+++ b/src/content/pages/download.rst
@@ -25,8 +25,8 @@ your dependencies using the
 You will have to use ``pack build`` instead of ``idris2 --build`` to compile a
 package.
 
-If you already use ``pack``, you can update your Idris version to the latest git
-commit (``HEAD``) by using ``pack switch latest``. If you wish to use a specific
+If you already use ``pack``, you can update your Idris version to the latest version 
+in development by using ``pack switch latest``[#f1]_. If you wish to use a specific
 release with ``pack``, currently the only way to do this is to find the release
 date, and then switch to its nightly collection by using, for example,
 ``pack switch nightly-231222`` (which would switch to the 0.7.0 release).
@@ -111,3 +111,7 @@ There are editor modes which support interactive editing:
   * `Vim mode (for Idris 1) <https://github.com/idris-hackers/idris-vim>`_
   * `Emacs mode (for Idris 1 and 2) <https://github.com/idris-hackers/idris-mode>`_
   * `(DEPRECATED) <https://github.blog/news-insights/product-news/sunsetting-atom/>`_ `Atom package <https://atom.io/packages/language-idris>`__
+
+.. rubric:: Footnotes
+
+.. [#f1] This version point to the latest git commit (``HEAD``) of the Idris 2 project.

--- a/src/content/pages/download.rst
+++ b/src/content/pages/download.rst
@@ -1,6 +1,18 @@
 Download
 ========
 
+Prerequisites
+-------------
+
+In order to install Idris 2, you need:
+
+* Either `Chez Scheme <https://cisco.github.io/ChezScheme/>`_ or
+  `Racket <https://racket-lang.org>`_, to build the bootstrapping Scheme source.
+* ``bash``, with ``realpath``. On Linux, you probably already have this. On
+  a Mac, you can install this with ``brew install coreutils``.
+* A C compiler, to build the library support code.
+
+
 Idris 2
 -------
 
@@ -30,13 +42,7 @@ scripts, or via other software):
 
 Both ``pack`` and the release tarball include generated Scheme sources
 sufficient for bootstrapping, so you don't need an existing Idris 2 system to
-build. You need:
-
-* Either `Chez Scheme <https://cisco.github.io/ChezScheme/>`_ or `Racket
-  <https://racket-lang.org>`_ to build the generated Scheme source
-* ``bash``, with ``realpath``. On Linux, you probably already have this. On
-  a Mac, you can install this with ``brew install coreutils``.
-* A C compiler, to build the library support code.
+build.
 
 You can always find the latest development version `on github
 <http://github.com/idris-lang/Idris2>`_:

--- a/src/content/pages/download.rst
+++ b/src/content/pages/download.rst
@@ -1,26 +1,21 @@
 Download
 ========
 
-
-*IMPORTANT: The Idris website and install instructions are out of date. We are
-working on rectifying this as soon as possible. In the meantime, for installing
-you will likely want to use*
-`pack <https://github.com/stefan-hoeck/idris2-pack>`__,
-*and for up-to-date information, please see the*
-`Idris2 GitHub Repository <https://github.com/idris-lang/Idris2/>`__.
-
-
 Idris 2
 -------
+
+To get the cutting edge version of the compiler, use the package manager ``pack`` –
+please see `pack's install & usage instructions <https://github.com/stefan-hoeck/idris2-pack>`_.
+
+``pack`` will also handle your dependencies using the `pack collection <https://github.com/stefan-hoeck/idris2-pack-db/blob/main/collections/HEAD.toml>`_.
+You will have to use ``pack build`` instead of idris to compile.
+
+If you already use ``pack``, you can update your idris version by using ``pack switch latest``.
 
 The latest released version is Idris2-0.7.0,
 `released 2023-12-22 <{filename}../posts/idris2-0-7-0-released.rst>`_.
 
-You can install and use Idris 2 via either:
-
-* ``pack``, the package manager – please see
-  `pack's install instructions <https://github.com/stefan-hoeck/idris2-pack>`_.
-* The release tarball –
+And its associated tarballs
   `idris2-0.7.0.tgz <{static}../releases/idris2-0.7.0.tgz>`_
   `(SHA 256 hash) <{static}../releases/idris2-0.7.0.tgz.sha256>`__.
 
@@ -37,8 +32,6 @@ You can always find the latest development version `on github
 <http://github.com/idris-lang/Idris2>`_:
 
 * ``git clone`` `https://github.com/idris-lang/Idris2.git <https://github.com/idris-lang/Idris2>`_
-
-Or by switching to the ``"latest"`` package collection if using ``pack``.
 
 Previous releases are also available:
 

--- a/src/content/pages/index.rst
+++ b/src/content/pages/index.rst
@@ -10,17 +10,6 @@ Idris: A Language for Type-Driven Development
 ..   :align: right
 
 
------
-
-*IMPORTANT: The Idris website and install instructions are out of date. We are
-working on rectifying this as soon as possible. In the meantime, for installing
-you will likely want to use*
-`pack <https://github.com/stefan-hoeck/idris2-pack>`__,
-*and for up-to-date information, please see the*
-`Idris2 GitHub Repository <https://github.com/idris-lang/Idris2/>`__.
-
------
-
 Idris is a programming language designed to encourage *Type-Driven
 Development*.
 


### PR DESCRIPTION
addresses one of the points for https://github.com/andrevidela/idris-documentation-tracking/issues/1

* removes the disclaimer about the instructions not being up to date, we're updating them now
* Add basic instructions to use pack like `pack switch latest` and `pack build`
* Link to the pack collection