### PR TITLE
Fix typo

### DIFF
--- a/src/content/pages/download.rst~
+++ b/src/content/pages/download.rst~
@@ -115,4 +115,4 @@ Idris 1 editor support existed in the form of:
 Footnotes
 ---------
 
-.. [#f1] This version points to the latest git commit (``HEAD``) of the Idris 2 project.
+.. [#f1] This version point to the latest git commit (``HEAD``) of the Idris 2 project.


### PR DESCRIPTION
Correct a simple typo in the Download page: "This version point" -> "This version points"