### PR TITLE
Community update

### DIFF
--- a/src/content/pages/index.rst
+++ b/src/content/pages/index.rst
@@ -57,20 +57,23 @@ Community
 
     There are some legacy tools and code available in the
     `idris-hackers <https://github.com/idris-hackers>`_ organisation.
-**Discord**
+**IRC**
+    There is also an irc channel ``#idris`` on `libera <https://libera.chat/>`_.
+    Point your irc client to ``irc.libera.chat`` then ``/join #idris``.
+    For a web interface, you can try `IRCCloud <https://www.irccloud.com/>`_.
+**Discord (DEPRECATED)**
+    *NOTE: The Discord will be read-only by 2026-05-25 UTC+1,* it is being
+    `deprecated in favour of Zulip <{filename}../posts/community-moving-to-zulip.rst>`_.
+
     There is an Idris community on `Discord <https://discord.com/>`_ with
     several channels for learning, help and different aspects of development.
     You can `get an invitation to join here <https://discord.gg/YXmWC5yKYM>`_
     This is currently probably the most active place for interactive discussion
     of Idris.
-**IRC**
-    There is also an irc channel ``#idris`` on `libera <https://libera.chat/>`_.
-    Point your irc client to ``irc.libera.chat`` then ``/join #idris``.
-    For a web interface, you can try `IRCCloud <https://www.irccloud.com/>`_.
-**Slack**
+**Slack (DEPRECATED)**
     There is an ``#idris`` channel on the 
     `Functional Programming <https://functionalprogramming.slack.com/>`_
-    Slack.
+    Slack. However, at the time of writing (2026-05-18), it is very rarely used.
 
 All participants in these forums are requested to abide by the 
 `community standards <{filename}./docs/standards.rst>`_.

--- a/src/content/pages/index.rst
+++ b/src/content/pages/index.rst
@@ -57,6 +57,12 @@ Community
 
     There are some legacy tools and code available in the
     `idris-hackers <https://github.com/idris-hackers>`_ organisation.
+**Zulip**
+    There is an Idris community on
+    `Zulip <https://idris-lang.zulipchat.com>`__,
+    with several channels for learning, help, and different aspects of
+    development.  This is probably the most active place for interactive
+    discussion of Idris and projects using it.
 **IRC**
     There is also an irc channel ``#idris`` on `libera <https://libera.chat/>`_.
     Point your irc client to ``irc.libera.chat`` then ``/join #idris``.
@@ -94,4 +100,11 @@ Idris has been generously supported by the following `EPSRC <https://epsrc.ukri.
 * `Programming as Conversation: Type-Driven Development in Action <https://gow.epsrc.ukri.org/NGBOViewGrant.aspx?GrantRef=EP/T007265/1>`_
 
 We are also grateful for the continuing support
-of `SICSA <http://www.sicsa.ac.uk/>`_, the Scottish Informatics and Computer Science Alliance
+of `SICSA <http://www.sicsa.ac.uk/>`_, the Scottish Informatics and Computer
+Science Alliance.
+
+Finally, we are grateful to
+`Zulip <https://zulip.com>`__
+(an organized team chat app designed for efficient communication) for providing
+us with a
+`sponsored Zulip Cloud Standard plan <{filename}../posts/zulip-sponsored-hosting.rst>`_.

--- a/src/content/posts/community-moving-to-zulip.rst
+++ b/src/content/posts/community-moving-to-zulip.rst
@@ -1,0 +1,33 @@
+The Idris Community Is Moving to Zulip
+######################################
+
+:date: 2026-05-18 15:00
+:tags: announcement,community
+:category: News
+:author: CodingCellist
+
+
+This was
+`announced on the mailing list <https://groups.google.com/g/idris-lang/c/3Xxd-NFmrlw>`__
+just over a month ago (but not on the website due to time limitations): the
+Idris community has been slowly but surely moving away from Discord to Zulip.
+Going forwards, the main way to chat with the Idris community will be through:
+
+`idris-lang.zulipchat.com <https://idris-lang.zulipchat.com>`__
+
+The Discord was originally set up during COVID to host virtual developer
+meetings through voice chat, video presentations, etc. and it accidentally stuck
+around and grew to the community we have today.  However, with Discord's recent
+move to requiring photo-ID, along with virtual events no longer being a
+priority, Discord no longer seems like the right place to be.  We are not making
+this decision lightly, we will undoubtedly lose a portion of the current members
+in the transition, but we can only moderate one place, and Zulip is the least
+evil option for now.  Zulip offers a thread-first communication model, including
+the option to move and merge messages in across threads, which more closely
+matches how Idris discussions tend to progress.  It is also able to offer
+mailing list integration, search-engine indexing for help/questions, and
+archival much more readily, which is something many members of the community
+have been requesting.
+
+See you on the Zulip!
+

--- a/src/content/posts/discord-read-only.rst
+++ b/src/content/posts/discord-read-only.rst
@@ -1,0 +1,22 @@
+The Idris Discord Is Now Read-Only
+##################################
+
+:date: 2026-05-22 16:00
+:tags: announcement,community
+:category: News
+:author: CodingCellist
+
+
+As mentioned in `an earlier post <{filename}./community-moving-to-zulip.rst>`_,
+today marks the day where the Idris community discord changes to read-only.  The
+Discord has served us extremely well and we are sorry to see it go (especially
+me, CC, as I was the one who set it up), but both changes to Discord as a
+platform and features which Zulip support but Discord doesn't mean it is time to
+change to something new.  The details are in the earlier post, as well as on the
+mailing list (and the now-read-only Discord).
+
+See you all on
+`idris-lang.zulipchat.com <https://idris-lang.zulipchat.com>`__!
+
+P.S. This also marks the end of the May 2026 Idris Developer Meeting.  A post
+about what it was like and what people worked on will be up soon.

--- a/src/content/posts/idris2-0-1-0-released.rst
+++ b/src/content/posts/idris2-0-1-0-released.rst
@@ -24,7 +24,7 @@ To get started, you can see:
 
 The installation has worked successfully on Linux, Mac and Raspberry Pi.  Please
 let us know (ideally via the `mailing list
-<{filename}../pages/community.rst>`_) how you get on with installing on
+<https://groups.google.com/forum/#!forum/idris-lang>`__) how you get on with installing on
 other platforms. It's likely to need some work before it will install on
 Windows - we'd really like this to work, so please also let us know if you can
 help.

--- a/src/content/posts/idris2-0-2-0-released.rst
+++ b/src/content/posts/idris2-0-2-0-released.rst
@@ -25,7 +25,7 @@ To get started, you can see:
 
 The installation has worked successfully on Linux, Windows, Mac and Raspberry
 Pi. Please let us know (ideally via the `mailing list
-<{filename}../pages/community.rst>`_) how you get on with installing on other
+<https://groups.google.com/forum/#!forum/idris-lang>`__) how you get on with installing on other
 platforms.
 
 The main changes since Idris 2 version 0.1 are:

--- a/src/content/posts/idris2-0-2-1-released.rst
+++ b/src/content/posts/idris2-0-2-1-released.rst
@@ -24,7 +24,7 @@ To get started, you can see:
 
 The installation has worked successfully on Linux, Windows, Mac and Raspberry
 Pi. Please let us know (ideally via the `mailing list
-<{filename}../pages/community.rst>`_) how you get on with installing on other
+<https://groups.google.com/forum/#!forum/idris-lang>`__) how you get on with installing on other
 platforms.
 
 Note that this is the last version that we guarantee will build with the

--- a/src/content/posts/idris2-0-3-0-released.rst
+++ b/src/content/posts/idris2-0-3-0-released.rst
@@ -24,7 +24,7 @@ To get started, you can see:
 
 The installation has worked successfully on Linux, Windows, Mac and Raspberry
 Pi. Please let us know (ideally via the `mailing list
-<{filename}../pages/community.rst>`_) how you get on with installing on other
+<https://groups.google.com/forum/#!forum/idris-lang>`__) how you get on with installing on other
 platforms.
 
 The main changes since Idris 2 version 0.2.2 are:

--- a/src/content/posts/idris2-0-5-0-released.rst
+++ b/src/content/posts/idris2-0-5-0-released.rst
@@ -26,7 +26,7 @@ To get started, you can see:
 
 The installation has worked successfully on Linux, Windows, Mac and Raspberry
 Pi. Please let us know (ideally via the `mailing list
-<{filename}../pages/community.rst>`_) how you get on with installing on other
+<https://groups.google.com/forum/#!forum/idris-lang>`__) how you get on with installing on other
 platforms.
 
 For a detailed list of changes, see

--- a/src/content/posts/idris2-0.4.0-released.rst
+++ b/src/content/posts/idris2-0.4.0-released.rst
@@ -26,7 +26,7 @@ To get started, you can see:
 
 The installation has worked successfully on Linux, Windows, Mac and Raspberry
 Pi. Please let us know (ideally via the `mailing list
-<{filename}../pages/community.rst>`_) how you get on with installing on other
+<https://groups.google.com/forum/#!forum/idris-lang>`__) how you get on with installing on other
 platforms.
 
 For a detailed list of changes, see

--- a/src/content/posts/idris2-0.6.0-released.rst
+++ b/src/content/posts/idris2-0.6.0-released.rst
@@ -26,7 +26,7 @@ To get started, you can see:
 
 The installation has (so far) worked successfully on Linux, Windows, and Mac.
 Please let us know (ideally via the `mailing list
-<{filename}../pages/community.rst>`_) how you get on with installing on other
+<https://groups.google.com/forum/#!forum/idris-lang>`__) how you get on with installing on other
 platforms.
 
 For a detailed list of changes, see

--- a/src/content/posts/zulip-sponsored-hosting.rst
+++ b/src/content/posts/zulip-sponsored-hosting.rst
@@ -1,0 +1,22 @@
+Idris Has Been Granted a Sponsored Zulip Cloud Standard Plan
+############################################################
+
+:date: 2026-01-23 20:17
+:tags: community
+:category: News
+:author: CodingCellist
+
+
+By virtue of being a free and open-source software project, the Idris Zulip has
+generously been granted a
+`sponsored Zulip Cloud Standard plan <https://zulip.com/help/zulip-cloud-billing#free-and-discounted-zulip-cloud-standard>`__,
+enabling us to make certain channels (for example, the `help` channel)
+web-public, meaning their contents will be indexed by search engines, hopefully
+allowing people to find answers to questions, without having to join a chat
+instance.  It also gives us unlimited search history, and
+`a bunch of other niceties <https://zulip.com/features/>`__.
+
+We are very grateful for this sponsorship and look forward to chatting with
+people on
+`the Idris Zulip <https://idris-lang.zulipchat.com>`__!
+


### PR DESCRIPTION
Some long overdue maintainance on the site:

* Fix bitrot in the old release posts to do with linking to the mailing list.
* Deprecate the Discord and Slack
* Announce the move to Zulip, and acknowledge them generously sponsoring us with a Zulip Cloud Standard plan.